### PR TITLE
feat: Search 페이지 레이아웃 및 로직 변경

### DIFF
--- a/src/pages/Loading/Loading.jsx
+++ b/src/pages/Loading/Loading.jsx
@@ -16,7 +16,9 @@ const Loading = () => {
     };
     console.log(data);
     if (!foodWant) navigate("/search");
-    recommendFood(foodWant, isSoup, data);
+    recommendFood(foodWant, isSoup, data).then((res) => {
+      console.log(res);
+    });
   }, []);
 
   const callback = () => {

--- a/src/pages/Loading/Loading.jsx
+++ b/src/pages/Loading/Loading.jsx
@@ -1,4 +1,3 @@
-import axios from "axios";
 import React, { useState, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { recommendFood } from "../../axios/find-food";
@@ -9,13 +8,12 @@ const Loading = () => {
   const savedCallback = useRef();
   const navigate = useNavigate();
   const location = useLocation();
-  const isSoup = true;
-  const { foodWant, bannedFood } = location.state || false;
+  const { foodWant, bannedFood, isSoup } = location.state || false;
 
   useEffect(() => {
     const data = {
-      'ban': bannedFood
-    }
+      ban: bannedFood,
+    };
     console.log(data);
     if (!foodWant) navigate("/search");
     recommendFood(foodWant, isSoup, data);

--- a/src/pages/Search/Search.jsx
+++ b/src/pages/Search/Search.jsx
@@ -18,6 +18,48 @@ const Search = () => {
     "감자탕",
   ];
 
+  const [currCheckedSoup, setCurrCheckedSoup] = useState(0);
+  const [prevCheckedSoup, setPrevCheckedSoup] = useState(0);
+
+  function ClickSoup(index) {
+    setPrevCheckedSoup(currCheckedSoup);
+    setCurrCheckedSoup(index);
+  }
+
+  const categorySoup = [
+    { index: 1, content: "국물 있음" },
+    { index: 2, content: "국물 없음" },
+    { index: 3, content: "상관 없음" },
+  ];
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleOpen = () => {
+    setIsOpen((isOpen) => !isOpen);
+  };
+
+  function Category(props) {
+    const isOpen = props.isOpen;
+    if (isOpen) {
+      return (
+        <>
+          <styled.Index>국물</styled.Index>
+          <styled.BtnBox>
+            {categorySoup.map((soup) => (
+              <styled.BtnContent
+                key={soup.index}
+                onClick={() => ClickSoup(soup.index)}
+                flag={currCheckedSoup === soup.index}
+              >
+                {soup.content}
+              </styled.BtnContent>
+            ))}
+          </styled.BtnBox>
+        </>
+      );
+    }
+  }
+
   const [bannedFood, setBannedFood] = useState([]);
   const [keyboard, setKeyboard] = useState(false);
   const [foodWant, setFoodWant] = useState("");
@@ -53,7 +95,7 @@ const Search = () => {
 
   const clickDropDownItem = (clickedItem) => {
     setInputValue(clickedItem);
-    setBannedFood([clickedItem, ...bannedFood])
+    setBannedFood([clickedItem, ...bannedFood]);
     setIsHaveInputValue(false);
     console.log(bannedFood);
   };
@@ -65,7 +107,7 @@ const Search = () => {
     setKeyboard(false);
   };
 
-  useEffect(() => console.log(bannedFood), [bannedFood])
+  useEffect(() => console.log(bannedFood), [bannedFood]);
 
   useEffect(showDropDownList, [inputValue]);
 
@@ -122,6 +164,8 @@ const Search = () => {
               })}
             </styled.DropDownBox>
           )}
+          <styled.Title onClick={() => toggleOpen()}>카테고리</styled.Title>
+          <Category isOpen={isOpen} />
         </div>
         <styled.BtnSearch
           keyboard={keyboard}

--- a/src/pages/Search/Search.jsx
+++ b/src/pages/Search/Search.jsx
@@ -92,7 +92,7 @@ const Search = () => {
             onBlur={blurFoodWant}
             onFocus={focusFoodWant}
             placeholder="ex. 약간 맵고 달달한 음식"
-          ></styled.Input>
+          />
           <styled.Title>먹기 싫은 음식</styled.Title>
           <styled.Input
             type="text"

--- a/src/pages/Search/Search.jsx
+++ b/src/pages/Search/Search.jsx
@@ -18,47 +18,12 @@ const Search = () => {
     "감자탕",
   ];
 
-  const [currCheckedSoup, setCurrCheckedSoup] = useState(0);
-  const [prevCheckedSoup, setPrevCheckedSoup] = useState(0);
-
-  function ClickSoup(index) {
-    setPrevCheckedSoup(currCheckedSoup);
-    setCurrCheckedSoup(index);
-  }
+  const [isSoup, setIsSoup] = useState(true);
 
   const categorySoup = [
-    { index: 1, content: "국물 있음" },
-    { index: 2, content: "국물 없음" },
-    { index: 3, content: "상관 없음" },
+    { bool: true, content: "국물 있음" },
+    { bool: false, content: "국물 없음" },
   ];
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  const toggleOpen = () => {
-    setIsOpen((isOpen) => !isOpen);
-  };
-
-  function Category(props) {
-    const isOpen = props.isOpen;
-    if (isOpen) {
-      return (
-        <>
-          <styled.Index>국물</styled.Index>
-          <styled.BtnBox>
-            {categorySoup.map((soup) => (
-              <styled.BtnContent
-                key={soup.index}
-                onClick={() => ClickSoup(soup.index)}
-                flag={currCheckedSoup === soup.index}
-              >
-                {soup.content}
-              </styled.BtnContent>
-            ))}
-          </styled.BtnBox>
-        </>
-      );
-    }
-  }
 
   const [bannedFood, setBannedFood] = useState([]);
   const [keyboard, setKeyboard] = useState(false);
@@ -71,7 +36,9 @@ const Search = () => {
 
   const navigateToLoading = () => {
     if (foodWant != "") {
-      navigate("/loading", { state: { foodWant, bannedFood } });
+      navigate("/loading", {
+        state: { foodWant, bannedFood, isSoup },
+      });
     }
   };
 
@@ -164,8 +131,18 @@ const Search = () => {
               })}
             </styled.DropDownBox>
           )}
-          <styled.Title onClick={() => toggleOpen()}>카테고리</styled.Title>
-          <Category isOpen={isOpen} />
+          <styled.Title>카테고리</styled.Title>
+          <styled.BtnBox>
+            {categorySoup.map((soup) => (
+              <styled.BtnContent
+                key={soup.bool}
+                onClick={() => setIsSoup(soup.bool)}
+                flag={isSoup === soup.bool}
+              >
+                {soup.content}
+              </styled.BtnContent>
+            ))}
+          </styled.BtnBox>
         </div>
         <styled.BtnSearch
           keyboard={keyboard}

--- a/src/pages/Search/styles.jsx
+++ b/src/pages/Search/styles.jsx
@@ -120,3 +120,36 @@ export const DropDownItem = styled.div`
     background-color: ${(props) => (props.noneItem ? "#FFFFFF" : "#E8E8F8")};
   }
 `;
+
+export const BtnBox = styled.div`
+  display: flex;
+  margin: 10px 0px 10px 0px;
+`;
+
+export const Index = styled.div`
+  font-family: "Noto Sans CJK KR";
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 21px;
+  /* identical to box height */
+  color: #191919;
+`;
+
+export const BtnContent = styled.button`
+  background: #ffffff;
+  border: 0.7px solid ${(props) => (props.flag ? "#005EEB" : "#999999")};
+  border-radius: 20px;
+  cursor: pointer;
+  font-family: "Noto Sans CJK KR";
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 18px;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: ${(props) => (props.flag ? "#005EEB" : "#999999")};
+  padding: 5px 10px 5px 10px;
+  margin: 0px 4px 0px 0px;
+`;


### PR DESCRIPTION
- 기존에 보류한 카테고리 항목을 재활성화
- 카테고리 항목이 toggle의 형태가 아닌 사용자에게 상시 노출되도록 변경
- 기존 카테고리 항목(국물, 나라)에서 '나라' 카테고리 삭제
- '국물 있음' / '국물 없음' / '상관 없음' -> '국물 있음' / '국물 없음' 2가지로 축소
- 컴포넌트 간 state 전달 관련 코드 수정 및 적용